### PR TITLE
Improved tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,12 @@ cache:
 # install dependencies
 install:
   - travis_retry composer self-update
-  - travis_retry composer global require "codeception/codeception:2.2.5"
   - travis_retry composer global require "fxp/composer-asset-plugin:~1.1.0"
   - travis_retry composer install --prefer-dist
 
 before_script:
   - mysql -e 'create database dektrium_test;'
   - php tests/_app/yii.php migrate --migrationPath=@dektrium/user/migrations --interactive=0
-  - ~/.composer/vendor/bin/codecept build
+  - vendor/bin/codecept build
 
-script: ~/.composer/vendor/bin/codecept run
+script: vendor/bin/codecept run

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yii2-user [![Build Status](https://img.shields.io/travis/dektrium/yii2-user/master.svg?style=flat-square)](https://travis-ci.org/dektrium/yii2-user) [![Packagist Version](https://img.shields.io/packagist/v/dektrium/yii2-user.svg?style=flat-square)](https://packagist.org/packages/dektrium/yii2-user) [![Total Downloads](https://img.shields.io/packagist/dt/dektrium/yii2-user.svg?style=flat-square)](https://packagist.org/packages/dektrium/yii2-user) [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+# Yii2-user [![Build Status](https://img.shields.io/travis/dabilite/yii2-user/master.svg?style=flat-square)](https://travis-ci.org/dabilite/yii2-user) [![Packagist Version](https://img.shields.io/packagist/v/dabilite/yii2-user.svg?style=flat-square)](https://packagist.org/packages/dabilite/yii2-user) [![Total Downloads](https://img.shields.io/packagist/dt/dabilite/yii2-user.svg?style=flat-square)](https://packagist.org/packages/dabilite/yii2-user) [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 
 Most of web applications provide a way for users to register, log in or reset
 their forgotten passwords. Rather than re-implementing this on each application,
@@ -34,6 +34,8 @@ If you have any questions or problems with Yii2-user you can ask them on [our fo
 
 Anyone and everyone is welcome to contribute. Please take a moment to
 review the [guidelines for contributing](.github/CONTRIBUTING.md).
+Tests can be run locally via docker.
+Simply run `docker-compose run --rm functional-tests` and all tests will be run.
 
 ## License
 

--- a/codeception.yml
+++ b/codeception.yml
@@ -12,7 +12,7 @@ modules:
     config:
         Yii2:
             configFile: 'tests/_app/config/test.php'
-            cleanup: false
+#            cleanup: false
 coverage:
     enabled: true
     include:

--- a/codeception.yml
+++ b/codeception.yml
@@ -12,7 +12,6 @@ modules:
     config:
         Yii2:
             configFile: 'tests/_app/config/test.php'
-#            cleanup: false
 coverage:
     enabled: true
     include:

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         "yiisoft/yii2": "^2.0.0",
         "yiisoft/yii2-swiftmailer": "^2.0.0",
         "yiisoft/yii2-authclient": "^2.1.0",
-        "yiisoft/yii2-bootstrap": "^2.0.0"
+        "yiisoft/yii2-bootstrap": "^2.0.0",
+        "codeception/codeception": "^2.3"
     },
     "require-dev": {
-        "yiisoft/yii2-codeception": "^2.0.0",
         "codeception/specify": "^0.4.3",
         "codeception/verify": "^0.3.1"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '2'
+services:
+
+
+## Running tests
+  functional-tests:
+    extends: codeception
+    entrypoint: [
+      "/sbin/tini",
+      "--",
+      "/bin/wait-for-it",
+      "-h", "$$MYSQL_HOST:3306",
+      "-t", "100",
+       "--",
+      "/project/tests/runtests.sh",
+      "run functional"
+    ]
+    depends_on:
+      - mysql
+
+#    entrypoint: "ls /project"
+
+## Running unit tests
+  unit:
+      extends: codeception
+      entrypoint: [
+        "/sbin/tini",
+        "--",
+        "/bin/wait-for-it",
+        "-h", "$$DB_HOST:3306",
+        "-t", "100",
+        "--",
+        "/project/tests/runtests.sh",
+        "run unit"
+      ]
+      depends_on:
+        - mysql
+## Running codeception helper scripts.
+  codeception:
+    tty: true
+    image: sammousa/php-with-extensions
+    entrypoint: ["/sbin/tini", "--", "/project/tests/runtests.sh"]
+    volumes:
+      - ./:/project
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_USER: dabilite
+      MYSQL_PASSWORD: testpass
+      MYSQL_DATABASE: test
+#     We set this to keep compatibility between gitlab-ci and docker compose
+      RUNNER_IP: web
+      MYSQL_HOST: mysql
+      YII_ENV: "test"
+## Mysql server (local)
+  mysql:
+    image: mysql:5.7.14
+    tmpfs:
+      - /var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_USER: dabilite
+      MYSQL_PASSWORD: testpass
+      MYSQL_DATABASE: test
+

--- a/tests/_app/config/test.php
+++ b/tests/_app/config/test.php
@@ -18,6 +18,9 @@ return [
         ],
     ],
     'components' => [
+        'assetManager' => [
+            'basePath' => '/tmp'
+        ],
         'db' => require __DIR__ . '/db.php',
         'mailer' => [
             'useFileTransport' => true,

--- a/tests/_app/config/test.php
+++ b/tests/_app/config/test.php
@@ -18,9 +18,6 @@ return [
         ],
     ],
     'components' => [
-        'session' => [
-
-        ],
         'db' => require __DIR__ . '/db.php',
         'mailer' => [
             'useFileTransport' => true,

--- a/tests/_fixtures/ActiveFixture.php
+++ b/tests/_fixtures/ActiveFixture.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace tests\_fixtures;
+
+/**
+ * This test fixes issues with resetting autoincrement columns.
+ * @see https://github.com/yiisoft/yii2/issues/13625
+ * @package tests\_fixtures
+ *
+ */
+class ActiveFixture extends \yii\test\ActiveFixture
+{
+    /**
+     * Removes all existing data from the specified table and resets sequence number to 1 (if any).
+     * This method is called before populating fixture data into the table associated with this fixture.
+     */
+    protected function resetTable()
+    {
+//        parent::resetTable();
+        \Yii::info("Cleaing table");
+        $table = $this->getTableSchema();
+        $this->db->createCommand()->delete($table->fullName)->execute();
+    }
+}

--- a/tests/_fixtures/ActiveFixture.php
+++ b/tests/_fixtures/ActiveFixture.php
@@ -17,8 +17,7 @@ class ActiveFixture extends \yii\test\ActiveFixture
      */
     protected function resetTable()
     {
-//        parent::resetTable();
-        \Yii::info("Cleaing table");
+        \Yii::info("Cleaning table");
         $table = $this->getTableSchema();
         $this->db->createCommand()->delete($table->fullName)->execute();
     }

--- a/tests/_fixtures/ProfileFixture.php
+++ b/tests/_fixtures/ProfileFixture.php
@@ -2,8 +2,6 @@
 
 namespace tests\_fixtures;
 
-use yii\test\ActiveFixture;
-
 class ProfileFixture extends ActiveFixture
 {
     public $modelClass = 'dektrium\user\models\Profile';
@@ -11,4 +9,6 @@ class ProfileFixture extends ActiveFixture
     public $depends = [
         'tests\_fixtures\UserFixture'
     ];
+
+
 }

--- a/tests/_fixtures/TokenFixture.php
+++ b/tests/_fixtures/TokenFixture.php
@@ -2,8 +2,6 @@
 
 namespace tests\_fixtures;
 
-use yii\test\ActiveFixture;
-
 class TokenFixture extends ActiveFixture
 {
     public $modelClass = 'dektrium\user\models\Token';

--- a/tests/_fixtures/UserFixture.php
+++ b/tests/_fixtures/UserFixture.php
@@ -2,8 +2,6 @@
 
 namespace tests\_fixtures;
 
-use yii\test\ActiveFixture;
-
 class UserFixture extends ActiveFixture
 {
     public $modelClass = 'dektrium\user\models\User';

--- a/tests/_fixtures/data/sql/database.sql
+++ b/tests/_fixtures/data/sql/database.sql
@@ -1,1 +1,0 @@
-create database dektrium_test;

--- a/tests/_fixtures/data/user.php
+++ b/tests/_fixtures/data/user.php
@@ -4,6 +4,7 @@ $time = time();
 
 return [
     'user' => [
+        'id'            => 1,
         'username'      => 'user',
         'email'         => 'user@example.com',
         'password_hash' => '$2y$13$qY.ImaYBppt66qez6B31QO92jc5DYVRzo5NxM1ivItkW74WsSG6Ui',
@@ -13,6 +14,7 @@ return [
         'confirmed_at'  => $time,
     ],
     'unconfirmed' => [
+        'id'            => 2,
         'username'      => 'joe',
         'email'         => 'joe@example.com',
         'password_hash' => '$2y$13$CIH1LSMPzU9xDCywt3QO8uovAu2axp8hwuXVa72oI.1G/USsGyMBS',
@@ -21,6 +23,7 @@ return [
         'updated_at'    => $time,
     ],
     'unconfirmed_with_expired_token' => [
+        'id'            => 3,
         'username'      => 'john',
         'email'         => 'john@example.com',
         'password_hash' => '$2y$13$qY.ImaYBppt66qez6B31QO92jc5DYVRzo5NxM1ivItkW74WsSG6Ui',
@@ -29,6 +32,7 @@ return [
         'updated_at'    => $time - 86401,
     ],
     'blocked' => [
+        'id'            => 4,
         'username'      => 'steven',
         'email'         => 'steven@example.com',
         'password_hash' => '$2y$13$qY.ImaYBppt66qez6B31QO92jc5DYVRzo5NxM1ivItkW74WsSG6Ui',
@@ -39,6 +43,7 @@ return [
         'confirmed_at'  => $time,
     ],
     'user_with_expired_recovery_token' => [
+        'id'            => 5,
         'username'      => 'andrew',
         'email'         => 'andrew@example.com',
         'password_hash' => '$2y$13$qY.ImaYBppt66qez6B31QO92jc5DYVRzo5NxM1ivItkW74WsSG6Ui',
@@ -48,6 +53,7 @@ return [
         'confirmed_at'  => $time - 21601,
     ],
     'user_with_recovery_token' => [
+        'id'            => 6,
         'username'      => 'alex',
         'email'         => 'alex@example.com',
         'password_hash' => '$2y$13$qY.ImaYBppt66qez6B31QO92jc5DYVRzo5NxM1ivItkW74WsSG6Ui',

--- a/tests/_pages/AdminPage.php
+++ b/tests/_pages/AdminPage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents admin page.
  *

--- a/tests/_pages/BasePage.php
+++ b/tests/_pages/BasePage.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace tests\_pages;
+use \Yii;
+class BasePage
+{
+    /**
+     * @var string|array the route (controller ID and action ID, e.g. `site/about`) to this page.
+     * Use array to represent a route with GET parameters. The first element of the array represents
+     * the route and the rest of the name-value pairs are treated as GET parameters, e.g. `array('site/page', 'name' => 'about')`.
+     */
+    public $route;
+    /**
+     * @var \Codeception\Actor the testing guy object
+     */
+    protected $actor;
+
+    /**
+     * Constructor.
+     *
+     * @param \Codeception\Actor $I the testing guy object
+     */
+    public function __construct($I)
+    {
+        $this->actor = $I;
+    }
+
+    /**
+     * Returns the URL to this page.
+     * The URL will be returned by calling the URL manager of the application
+     * with [[route]] and the provided parameters.
+     * @param array $params the GET parameters for creating the URL
+     * @return string the URL to this page
+     * @throws InvalidConfigException if [[route]] is not set or invalid
+     */
+    public function getUrl($params = [])
+    {
+        if (is_string($this->route)) {
+            $params[0] = $this->route;
+            return Yii::$app->getUrlManager()->createUrl($params);
+        } elseif (is_array($this->route) && isset($this->route[0])) {
+            return Yii::$app->getUrlManager()->createUrl(array_merge($this->route, $params));
+        } else {
+            throw new InvalidConfigException('The "route" property must be set.');
+        }
+    }
+
+    /**
+     * Creates a page instance and sets the test guy to use [[url]].
+     * @param \Codeception\Actor $I the test guy instance
+     * @param array $params the GET parameters to be used to generate [[url]]
+     * @return static the page instance
+     */
+    public static function openBy($I, $params = [])
+    {
+        $page = new static($I);
+        $I->amOnPage($page->getUrl($params));
+        return $page;
+    }
+}

--- a/tests/_pages/CreatePage.php
+++ b/tests/_pages/CreatePage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents admin create page.
  *

--- a/tests/_pages/LoginPage.php
+++ b/tests/_pages/LoginPage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents login page.
  *

--- a/tests/_pages/RecoveryPage.php
+++ b/tests/_pages/RecoveryPage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents resend page.
  *

--- a/tests/_pages/RegistrationPage.php
+++ b/tests/_pages/RegistrationPage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents registration page.
  *

--- a/tests/_pages/ResendPage.php
+++ b/tests/_pages/ResendPage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents resend page.
  *

--- a/tests/_pages/SettingsPage.php
+++ b/tests/_pages/SettingsPage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents email settings page.
  *

--- a/tests/_pages/UpdatePage.php
+++ b/tests/_pages/UpdatePage.php
@@ -2,8 +2,6 @@
 
 namespace tests\_pages;
 
-use yii\codeception\BasePage;
-
 /**
  * Represents admin update page.
  *


### PR DESCRIPTION
This removes the deprecated `yii2-codeception` page and refactors tests to use the new functionality that's available via codeception itself.

Added local test runner configuration, see README.

