### PR TITLE
Bug fixes

### DIFF
--- a/models/UserSearch.php
+++ b/models/UserSearch.php
@@ -103,7 +103,8 @@ class UserSearch extends Model
             $query->andFilterWhere(['item_name' => $this->auth_item]);
         }
 
-        $table_name = $query->modelClass::tableName();
+        $model = $query->modelClass;
+        $table_name = $model::tableName();
 
         if ($this->created_at !== null) {
             $date = strtotime($this->created_at);

--- a/views/admin/index.php
+++ b/views/admin/index.php
@@ -139,7 +139,7 @@ $this->params['breadcrumbs'][] = $this->title;
                     }
                 },
                 'switch' => function ($url, $model) {
-                    if($model->isAdmin && $model->id != Yii::$app->user->id && Yii::$app->getModule('user')->enableImpersonateUser) {
+                    if(!$model->isAdmin && $model->id != Yii::$app->user->id && Yii::$app->getModule('user')->enableImpersonateUser) {
                         return Html::a('<span class="glyphicon glyphicon-user"></span>', ['/user/admin/switch', 'id' => $model->id], [
                             'title' => Yii::t('user', 'Become this user'),
                             'data-confirm' => Yii::t('user', 'Are you sure you want to switch to this user for the rest of this Session?'),


### PR DESCRIPTION
Fix for bug introduced in UserSearch.php ($query->modelClass::tableName() gives an error on PHP 5.6).

Fix for bug where only admin users can be impersonated (while it should be that only NON-admin users can be impersonated).

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
