### PR TITLE
Php 5.6 compatibility

### DIFF
--- a/models/UserSearch.php
+++ b/models/UserSearch.php
@@ -103,7 +103,8 @@ class UserSearch extends Model
             $query->andFilterWhere(['item_name' => $this->auth_item]);
         }
 
-        $table_name = $query->modelClass::tableName();
+        $modelClass = $query->modelClass;
+        $table_name = $modelClass::tableName();
 
         if ($this->created_at !== null) {
             $date = strtotime($this->created_at);


### PR DESCRIPTION
On PHP 5.6 the /user/admin page raises an error with syntax error.
This works for latest versions, but as it's just 1 line of code, better keep compatibility.