### PR TITLE
fix welcome text-email missing $showPassword var

### DIFF
--- a/views/mail/text/welcome.php
+++ b/views/mail/text/welcome.php
@@ -12,6 +12,7 @@
 
 /**
  * @var dektrium\user\models\User $user
+ * @var bool $showPassword
  */
 ?>
 <?= Yii::t('user', 'Hello') ?>,
@@ -19,7 +20,7 @@
 <?= Yii::t('user', 'Your account on {0} has been created', Yii::$app->name) ?>.
 <?= Yii::t('user', 'Your username is') ?>:
 <?= $user->username?>
-<?php if ($module->enableGeneratingPassword): ?>
+<?php if ($showPassword || $module->enableGeneratingPassword): ?>
 <?= Yii::t('user', 'We have generated a password for you') ?>:
 <?= $user->password ?>
 <?php endif ?>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| Fixed issues  | text welcome email is missing the $showPassword variable option used in HTML