### PR TITLE
Add a new setting (emailAsUsername) to avoid requesting the username and set it equal to the email

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -60,6 +60,9 @@ class Module extends BaseModule
     /** @var int Email changing strategy. */
     public $emailChangeStrategy = self::STRATEGY_DEFAULT;
 
+    /** @var bool Avoid asking username during registration and set it equal to email */
+    public $emailAsUsername = false;
+
     /** @var int The time you want the user will be remembered without asking for credentials. */
     public $rememberFor = 1209600; // two weeks
 

--- a/models/RegistrationForm.php
+++ b/models/RegistrationForm.php
@@ -49,7 +49,7 @@ class RegistrationForm extends Model
             // username rules
             'usernameTrim'     => ['username', 'trim'],
             'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
-            'usernamePattern'  => ['username', 'match', 'pattern' => $user::$usernameRegexp],
+            'usernamePattern'  => ($this->module->emailAsUsername ? ['username', 'email'] : ['username', 'match', 'pattern' => $user::$usernameRegexp]),
             'usernameRequired' => ['username', 'required'],
             'usernameUnique'   => [
                 'username',
@@ -92,6 +92,13 @@ class RegistrationForm extends Model
     {
         return 'register-form';
     }
+
+	public function beforeValidate() {
+		if ($this->module->emailAsUsername) {
+			$this->username = $this->email;
+		}
+	    return parent::beforeValidate();
+	}
 
     /**
      * Registers a new user account. If registration was successful it will set flash message.

--- a/models/SettingsForm.php
+++ b/models/SettingsForm.php
@@ -75,7 +75,7 @@ class SettingsForm extends Model
             'usernameTrim' => ['username', 'trim'],
             'usernameRequired' => ['username', 'required'],
             'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
-            'usernamePattern' => ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@]+$/'],
+            'usernamePattern' => ($this->module->emailAsUsername ? ['username', 'email'] : ['username', 'match', 'pattern' => '/^[-a-zA-Z0-9_\.@]+$/']),
             'emailTrim' => ['email', 'trim'],
             'emailRequired' => ['email', 'required'],
             'emailPattern' => ['email', 'email'],
@@ -107,6 +107,13 @@ class SettingsForm extends Model
     public function formName()
     {
         return 'settings-form';
+    }
+
+    public function beforeValidate() {
+        if ($this->module->emailAsUsername) {
+            $this->username = $this->email;
+        }
+        return parent::beforeValidate();
     }
 
     /**

--- a/models/User.php
+++ b/models/User.php
@@ -238,7 +238,7 @@ class User extends ActiveRecord implements IdentityInterface
             // username rules
             'usernameTrim'     => ['username', 'trim'],
             'usernameRequired' => ['username', 'required', 'on' => ['register', 'create', 'connect', 'update']],
-            'usernameMatch'    => ['username', 'match', 'pattern' => static::$usernameRegexp],
+            'usernameMatch'    => ($this->module->emailAsUsername ? ['username', 'email'] : ['username', 'match', 'pattern' => static::$usernameRegexp]),
             'usernameLength'   => ['username', 'string', 'min' => 3, 'max' => 255],
             'usernameUnique'   => [
                 'username',
@@ -267,6 +267,19 @@ class User extends ActiveRecord implements IdentityInterface
     public function validateAuthKey($authKey)
     {
         return $this->getAttribute('auth_key') === $authKey;
+    }
+
+    /**
+     * This method is invoked before validation starts.
+     * If emailAsUsername setting is true, it copies email to username
+     *
+     * @return bool
+     */
+    public function beforeValidate() {
+        if ($this->module->emailAsUsername) {
+            $this->username = $this->email;
+        }
+        return parent::beforeValidate();
     }
 
     /**

--- a/views/registration/register.php
+++ b/views/registration/register.php
@@ -36,7 +36,9 @@ $this->params['breadcrumbs'][] = $this->title;
 
                 <?= $form->field($model, 'email') ?>
 
+                <?php if ($module->emailAsUsername == false): ?>
                 <?= $form->field($model, 'username') ?>
+                <?php endif ?>
 
                 <?php if ($module->enableGeneratingPassword == false): ?>
                     <?= $form->field($model, 'password')->passwordInput() ?>

--- a/views/settings/account.php
+++ b/views/settings/account.php
@@ -20,9 +20,10 @@ use yii\widgets\ActiveForm;
 
 $this->title = Yii::t('user', 'Account settings');
 $this->params['breadcrumbs'][] = $this->title;
+$module = Yii::$app->getModule('user');
 ?>
 
-<?= $this->render('/_alert', ['module' => Yii::$app->getModule('user')]) ?>
+<?= $this->render('/_alert', ['module' => $module]) ?>
 
 <div class="row">
     <div class="col-md-3">
@@ -47,7 +48,9 @@ $this->params['breadcrumbs'][] = $this->title;
 
                 <?= $form->field($model, 'email') ?>
 
+                <?php if ($module->emailAsUsername == false): ?>
                 <?= $form->field($model, 'username') ?>
+                <?php endif ?>
 
                 <?= $form->field($model, 'new_password')->passwordInput() ?>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
